### PR TITLE
Add interactive chat and dev admin tools

### DIFF
--- a/template/app/.env.server.example
+++ b/template/app/.env.server.example
@@ -25,6 +25,8 @@ PAYMENTS_CREDITS_10_PLAN_ID=012345
 
 # set this as a comma-separated list of emails you want to give admin privileges to upon registeration
 ADMIN_EMAILS=me@example.com,you@example.com,them@example.com
+# developers with access to /admin
+DEV_EMAILS=dev@example.com
 
 # see our guide for setting up google auth: https://wasp.sh/docs/auth/social-auth/google
 GOOGLE_CLIENT_ID=722...
@@ -54,3 +56,4 @@ AWS_S3_IAM_ACCESS_KEY=ACK...
 AWS_S3_IAM_SECRET_KEY=t+33a...
 AWS_S3_FILES_BUCKET=your-bucket-name
 AWS_S3_REGION=your-region
+AXYN_API_URL=http://localhost:8000

--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -96,9 +96,19 @@ app OpenSaaS {
   },
 }
 
-route LandingPageRoute { path: "/", to: LandingPage }
-page LandingPage {
-  component: import LandingPage from "@src/landing-page/LandingPage"
+route MainRoute { path: "/", to: MainPage }
+page MainPage {
+  component: import MainPage from "@src/client/pages/MainPage"
+}
+
+route AppRoute { path: "/app", to: AppPage }
+page AppPage {
+  component: import AppPage from "@src/client/pages/AppPage"
+}
+
+route LabsRoute { path: "/labs", to: LabsPage }
+page LabsPage {
+  component: import LabsPage from "@src/client/pages/LabsPage"
 }
 
 //#region Auth Pages
@@ -184,6 +194,18 @@ query getAllTasksByUser {
 }
 //#endregion
 
+//#region Axyn AI
+action AskAgent {
+  fn: import { askAgent } from "@server/ai/agent.ts",
+  entities: []
+}
+
+action LogMemory {
+  fn: import { logMemory } from "@server/ai/memory.ts",
+  entities: []
+}
+//#endregion
+
 //#region Payment
 route PricingPageRoute { path: "/pricing", to: PricingPage }
 page PricingPage {
@@ -257,7 +279,13 @@ job dailyStatsJob {
 //#endregion
 
 //#region Admin Dashboard
-route AdminRoute { path: "/admin", to: AnalyticsDashboardPage }
+route AdminRoute { path: "/admin", to: AdminPage }
+page AdminPage {
+  authRequired: true,
+  component: import AdminPage from "@src/client/pages/AdminPage"
+}
+
+route AdminAnalyticsRoute { path: "/admin/analytics", to: AnalyticsDashboardPage }
 page AnalyticsDashboardPage {
   authRequired: true,
   component: import AnalyticsDashboardPage from "@src/admin/dashboards/analytics/AnalyticsDashboardPage"

--- a/template/app/schema.prisma
+++ b/template/app/schema.prisma
@@ -14,6 +14,7 @@ model User {
   email                     String?         @unique
   username                  String?         @unique
   isAdmin                   Boolean         @default(false)
+  isDev                     Boolean         @default(false)
 
   paymentProcessorUserId    String?         @unique
   lemonSqueezyCustomerPortalUrl String?     // You can delete this if you're not using Lemon Squeezy as your payments processor.

--- a/template/app/src/auth/userSignupFields.ts
+++ b/template/app/src/auth/userSignupFields.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { defineUserSignupFields } from 'wasp/auth/providers/types';
 
 const adminEmails = process.env.ADMIN_EMAILS?.split(',') || [];
+const devEmails = process.env.DEV_EMAILS?.split(',') || [];
 
 const emailDataSchema = z.object({
   email: z.string(),
@@ -19,6 +20,10 @@ export const getEmailUserFields = defineUserSignupFields({
   isAdmin: (data) => {
     const emailData = emailDataSchema.parse(data);
     return adminEmails.includes(emailData.email);
+  },
+  isDev: (data) => {
+    const emailData = emailDataSchema.parse(data);
+    return devEmails.includes(emailData.email);
   },
 });
 
@@ -52,6 +57,14 @@ export const getGitHubUserFields = defineUserSignupFields({
       return false;
     }
     return adminEmails.includes(emailInfo.email);
+  },
+  isDev: (data) => {
+    const githubData = githubDataSchema.parse(data);
+    const emailInfo = getGithubEmailInfo(githubData);
+    if (!emailInfo.verified) {
+      return false;
+    }
+    return devEmails.includes(emailInfo.email);
   },
 });
 
@@ -92,6 +105,13 @@ export const getGoogleUserFields = defineUserSignupFields({
     }
     return adminEmails.includes(googleData.profile.email);
   },
+  isDev: (data) => {
+    const googleData = googleDataSchema.parse(data);
+    if (!googleData.profile.email_verified) {
+      return false;
+    }
+    return devEmails.includes(googleData.profile.email);
+  },
 });
 
 export function getGoogleAuthConfig() {
@@ -127,6 +147,13 @@ export const getDiscordUserFields = defineUserSignupFields({
       return false;
     }
     return adminEmails.includes(discordData.profile.email);
+  },
+  isDev: (data) => {
+    const discordData = discordDataSchema.parse(data);
+    if (!discordData.profile.email || !discordData.profile.verified) {
+      return false;
+    }
+    return devEmails.includes(discordData.profile.email);
   },
 });
 

--- a/template/app/src/client/pages/AdminPage.tsx
+++ b/template/app/src/client/pages/AdminPage.tsx
@@ -1,0 +1,69 @@
+import { useAuth } from 'wasp/client/auth';
+import { logMemory } from 'wasp/client/operations';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type MemoryEntry = { id: number; text: string };
+
+const initialEntries: MemoryEntry[] = [
+  { id: 1, text: 'Welcome to Norian memory log.' },
+  { id: 2, text: 'This is a sample memory item.' },
+];
+
+export default function AdminPage() {
+  const { data: user } = useAuth();
+  const navigate = useNavigate();
+  const [entries, setEntries] = useState<MemoryEntry[]>(initialEntries);
+  const [newEntry, setNewEntry] = useState('');
+
+  useEffect(() => {
+    if (user && !user.isDev) {
+      navigate('/');
+    }
+  }, [user, navigate]);
+
+  if (!user?.isDev) {
+    return <div className='py-10'>Access Denied</div>;
+  }
+
+  const handleInject = async () => {
+    if (!newEntry.trim()) return;
+    try {
+      await logMemory({ memory: newEntry });
+      setEntries((prev) => [...prev, { id: Date.now(), text: newEntry }]);
+      setNewEntry('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleClear = () => setEntries([]);
+
+  return (
+    <div className='py-10 space-y-6'>
+      <h1 className='text-4xl font-bold'>Admin Tools</h1>
+      <div>
+        <h2 className='text-lg font-semibold mb-2'>Memory Log</h2>
+        <ul className='list-disc pl-6 space-y-1'>
+          {entries.map((m) => (
+            <li key={m.id}>{m.text}</li>
+          ))}
+        </ul>
+      </div>
+      <div className='flex flex-col sm:flex-row gap-2'>
+        <input
+          className='flex-1 border rounded-md p-2'
+          value={newEntry}
+          onChange={(e) => setNewEntry(e.target.value)}
+          placeholder='Memory text'
+        />
+        <button onClick={handleInject} className='px-4 py-2 bg-purple-600 text-white rounded-md'>
+          Inject Memory
+        </button>
+        <button onClick={handleClear} className='px-4 py-2 bg-gray-200 rounded-md'>
+          Clear Memory
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/AppPage.tsx
+++ b/template/app/src/client/pages/AppPage.tsx
@@ -1,0 +1,58 @@
+import { askAgent } from 'wasp/client/operations';
+import { useState } from 'react';
+
+type ChatMessage = { role: 'user' | 'assistant'; text: string };
+
+export default function AppPage() {
+  const [prompt, setPrompt] = useState('');
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!prompt.trim()) return;
+    const currentPrompt = prompt;
+    setMessages((prev) => [...prev, { role: 'user', text: currentPrompt }]);
+    setPrompt('');
+    try {
+      setLoading(true);
+      const res = await askAgent({ prompt: currentPrompt });
+      const reply = res?.reply || res?.response || JSON.stringify(res);
+      setMessages((prev) => [...prev, { role: 'assistant', text: reply }]);
+    } catch (err) {
+      console.error(err);
+      setMessages((prev) => [...prev, { role: 'assistant', text: 'Error fetching response.' }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className='py-10 space-y-6'>
+      <h1 className='text-4xl font-bold'>Dashboard</h1>
+      <div className='space-y-3'>
+        {messages.map((m, idx) => (
+          <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+            <span className='inline-block rounded-md px-3 py-2 bg-gray-100'>{m.text}</span>
+          </div>
+        ))}
+        {loading && <div className='text-gray-500 italic'>Thinking...</div>}
+      </div>
+      <div className='flex gap-2'>
+        <input
+          className='flex-1 border rounded-md p-2'
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+          placeholder='Ask the AI...'
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={loading || !prompt.trim()}
+          className='px-4 py-2 bg-purple-600 text-white rounded-md disabled:opacity-50'
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/LabsPage.tsx
+++ b/template/app/src/client/pages/LabsPage.tsx
@@ -1,0 +1,8 @@
+export default function LabsPage() {
+  return (
+    <div className='py-10'>
+      <h1 className='text-4xl font-bold'>Labs</h1>
+      <p className='mt-4 text-lg'>Explore cooperative R&amp;D experiments here.</p>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/MainPage.tsx
+++ b/template/app/src/client/pages/MainPage.tsx
@@ -1,0 +1,8 @@
+export default function MainPage() {
+  return (
+    <div className='py-10'>
+      <h1 className='text-4xl font-bold'>Welcome to Norian</h1>
+      <p className='mt-4 text-lg'>This page uses the Building Blocks template.</p>
+    </div>
+  );
+}

--- a/template/app/src/server/ai/agent.ts
+++ b/template/app/src/server/ai/agent.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const askAgent = async (_args: { prompt: string }, context: any) => {
+  const token = context.user?.token;
+  const response = await axios.post(
+    process.env.AXYN_API_URL + '/api/cortex/ask',
+    { prompt: _args.prompt },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return response.data;
+};

--- a/template/app/src/server/ai/memory.ts
+++ b/template/app/src/server/ai/memory.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const logMemory = async (_args: { memory: string }, context: any) => {
+  const token = context.user?.token;
+  await axios.post(
+    process.env.AXYN_API_URL + '/api/mind/log',
+    { memory: _args.memory },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return { status: 'ok' };
+};

--- a/template/app/src/server/scripts/dbSeeds.ts
+++ b/template/app/src/server/scripts/dbSeeds.ts
@@ -35,6 +35,7 @@ function generateMockUserData(): MockUserData {
     username: faker.internet.userName({ firstName, lastName }),
     createdAt,
     isAdmin: false,
+    isDev: false,
     credits,
     subscriptionStatus,
     lemonSqueezyCustomerPortalUrl: null,


### PR DESCRIPTION
## Summary
- add isDev flag on user model and DEV_EMAILS env variable
- restrict admin route to authenticated devs
- implement memory viewer on /admin with mock data
- make /app page an AI chat interface using askAgent

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68444f5a04e88333b1cc1633924956fd

## Summary by Sourcery

Introduce a developer mode flag and related tools, protect the admin route for developers, and add an AI-powered chat interface along with new placeholder pages.

New Features:
- Add `isDev` flag to user model and `DEV_EMAILS` environment variable to mark developer accounts
- Implement a developer-only AdminPage with a memory log viewer and inject/clear controls
- Create an AI chat Dashboard page at `/app` using the `askAgent` operation
- Add placeholder LabsPage and MainPage routes

Enhancements:
- Update auth providers (email, GitHub, Google, Discord) to support `isDev`
- Protect the admin route by redirecting non-developer users to the homepage
- Include `isDev` field in database seed data

Chores:
- Update `.env.server.example` with `DEV_EMAILS` entry