### PR TITLE
Add Personality Manager UI

### DIFF
--- a/template/app/.env.server.example
+++ b/template/app/.env.server.example
@@ -25,6 +25,8 @@ PAYMENTS_CREDITS_10_PLAN_ID=012345
 
 # set this as a comma-separated list of emails you want to give admin privileges to upon registeration
 ADMIN_EMAILS=me@example.com,you@example.com,them@example.com
+# developers with access to /admin
+DEV_EMAILS=dev@example.com
 
 # see our guide for setting up google auth: https://wasp.sh/docs/auth/social-auth/google
 GOOGLE_CLIENT_ID=722...
@@ -54,3 +56,4 @@ AWS_S3_IAM_ACCESS_KEY=ACK...
 AWS_S3_IAM_SECRET_KEY=t+33a...
 AWS_S3_FILES_BUCKET=your-bucket-name
 AWS_S3_REGION=your-region
+AXYN_API_URL=http://localhost:8000

--- a/template/app/main.wasp
+++ b/template/app/main.wasp
@@ -96,9 +96,19 @@ app OpenSaaS {
   },
 }
 
-route LandingPageRoute { path: "/", to: LandingPage }
-page LandingPage {
-  component: import LandingPage from "@src/landing-page/LandingPage"
+route MainRoute { path: "/", to: MainPage }
+page MainPage {
+  component: import MainPage from "@src/client/pages/MainPage"
+}
+
+route AppRoute { path: "/app", to: AppPage }
+page AppPage {
+  component: import AppPage from "@src/client/pages/AppPage"
+}
+
+route LabsRoute { path: "/labs", to: LabsPage }
+page LabsPage {
+  component: import LabsPage from "@src/client/pages/LabsPage"
 }
 
 //#region Auth Pages
@@ -133,6 +143,18 @@ route AccountRoute { path: "/account", to: AccountPage }
 page AccountPage {
   authRequired: true,
   component: import Account from "@src/user/AccountPage"
+}
+
+route ProfileRoute { path: "/profile", to: ProfilePage }
+page ProfilePage {
+  authRequired: true,
+  component: import ProfilePage from "@src/client/pages/ProfilePage"
+}
+
+route PersonalitiesRoute { path: "/personalities", to: PersonalitiesPage }
+page PersonalitiesPage {
+  authRequired: true,
+  component: import PersonalitiesPage from "@src/client/pages/PersonalitiesPage"
 }
 
 query getPaginatedUsers {
@@ -181,6 +203,43 @@ query getGptResponses {
 query getAllTasksByUser {
   fn: import { getAllTasksByUser } from "@src/demo-ai-app/operations",
   entities: [Task]
+}
+//#endregion
+
+//#region Axyn AI
+action AskAgent {
+  fn: import { askAgent } from "@server/ai/agent.ts",
+  entities: []
+}
+
+action LogMemory {
+  fn: import { logMemory } from "@server/ai/memory.ts",
+  entities: []
+}
+
+action AskAgentPublic {
+  fn: import { askPublicAgent } from "@server/ai/publicAgent.ts",
+  entities: []
+}
+
+query getPreferences {
+  fn: import { getPreferences } from "@server/preferences.ts",
+  entities: [User, Preferences]
+}
+
+action updatePreferences {
+  fn: import { updatePreferences } from "@server/preferences.ts",
+  entities: [Preferences]
+}
+
+action togglePublicMode {
+  fn: import { togglePublicMode } from "@server/preferences.ts",
+  entities: [User]
+}
+
+query getPublicUser {
+  fn: import { getPublicUser } from "@server/preferences.ts",
+  entities: [User]
 }
 //#endregion
 
@@ -257,7 +316,19 @@ job dailyStatsJob {
 //#endregion
 
 //#region Admin Dashboard
-route AdminRoute { path: "/admin", to: AnalyticsDashboardPage }
+route AdminRoute { path: "/admin", to: AdminPage }
+page AdminPage {
+  authRequired: true,
+  component: import AdminPage from "@src/client/pages/AdminPage"
+}
+
+route TimelineRoute { path: "/timeline", to: TimelinePage }
+page TimelinePage {
+  authRequired: true,
+  component: import TimelinePage from "@src/client/pages/TimelinePage"
+}
+
+route AdminAnalyticsRoute { path: "/admin/analytics", to: AnalyticsDashboardPage }
 page AnalyticsDashboardPage {
   authRequired: true,
   component: import AnalyticsDashboardPage from "@src/admin/dashboards/analytics/AnalyticsDashboardPage"
@@ -309,6 +380,11 @@ route AdminUIButtonsRoute { path: "/admin/ui/buttons", to: AdminUIButtonsPage }
 page AdminUIButtonsPage {
   authRequired: true,
   component: import AdminUI from "@src/admin/elements/ui-elements/ButtonsPage"
+}
+
+route PublicRoute { path: "/share/:username", to: PublicPage }
+page PublicPage {
+  component: import PublicPage from "@src/client/pages/PublicPage"
 }
 
 route NotFoundRoute { path: "*", to: NotFoundPage }

--- a/template/app/schema.prisma
+++ b/template/app/schema.prisma
@@ -14,6 +14,11 @@ model User {
   email                     String?         @unique
   username                  String?         @unique
   isAdmin                   Boolean         @default(false)
+  isDev                     Boolean         @default(false)
+  isPublic                  Boolean         @default(false)
+  displayName               String?
+  preferencesJson           String?
+  preferences               Preferences?
 
   paymentProcessorUserId    String?         @unique
   lemonSqueezyCustomerPortalUrl String?     // You can delete this if you're not using Lemon Squeezy as your payments processor.
@@ -109,4 +114,14 @@ model ContactFormMessage {
   content                   String
   isRead                    Boolean         @default(false)
   repliedAt                 DateTime?
+}
+
+model Preferences {
+  id             String   @id @default(uuid())
+  user           User     @relation(fields: [userId], references: [id])
+  userId         String   @unique
+  useMemory      Boolean  @default(false)
+  loadSaved      Boolean  @default(false)
+  usePersonality Boolean  @default(false)
+  updatedAt      DateTime @updatedAt
 }

--- a/template/app/src/auth/userSignupFields.ts
+++ b/template/app/src/auth/userSignupFields.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { defineUserSignupFields } from 'wasp/auth/providers/types';
 
 const adminEmails = process.env.ADMIN_EMAILS?.split(',') || [];
+const devEmails = process.env.DEV_EMAILS?.split(',') || [];
 
 const emailDataSchema = z.object({
   email: z.string(),
@@ -20,6 +21,13 @@ export const getEmailUserFields = defineUserSignupFields({
     const emailData = emailDataSchema.parse(data);
     return adminEmails.includes(emailData.email);
   },
+  isDev: (data) => {
+    const emailData = emailDataSchema.parse(data);
+    return devEmails.includes(emailData.email);
+  },
+  isPublic: () => false,
+  displayName: () => '',
+  preferencesJson: () => '{}',
 });
 
 const githubDataSchema = z.object({
@@ -53,6 +61,17 @@ export const getGitHubUserFields = defineUserSignupFields({
     }
     return adminEmails.includes(emailInfo.email);
   },
+  isDev: (data) => {
+    const githubData = githubDataSchema.parse(data);
+    const emailInfo = getGithubEmailInfo(githubData);
+    if (!emailInfo.verified) {
+      return false;
+    }
+    return devEmails.includes(emailInfo.email);
+  },
+  isPublic: () => false,
+  displayName: () => '',
+  preferencesJson: () => '{}',
 });
 
 // We are using the first email from the list of emails returned by GitHub.
@@ -92,6 +111,16 @@ export const getGoogleUserFields = defineUserSignupFields({
     }
     return adminEmails.includes(googleData.profile.email);
   },
+  isDev: (data) => {
+    const googleData = googleDataSchema.parse(data);
+    if (!googleData.profile.email_verified) {
+      return false;
+    }
+    return devEmails.includes(googleData.profile.email);
+  },
+  isPublic: () => false,
+  displayName: () => '',
+  preferencesJson: () => '{}',
 });
 
 export function getGoogleAuthConfig() {
@@ -128,6 +157,16 @@ export const getDiscordUserFields = defineUserSignupFields({
     }
     return adminEmails.includes(discordData.profile.email);
   },
+  isDev: (data) => {
+    const discordData = discordDataSchema.parse(data);
+    if (!discordData.profile.email || !discordData.profile.verified) {
+      return false;
+    }
+    return devEmails.includes(discordData.profile.email);
+  },
+  isPublic: () => false,
+  displayName: () => '',
+  preferencesJson: () => '{}',
 });
 
 export function getDiscordAuthConfig() {

--- a/template/app/src/client/components/PersonalityCard.tsx
+++ b/template/app/src/client/components/PersonalityCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export type Personality = {
+  name: string;
+  description: string;
+  example: string;
+};
+
+type Props = {
+  personality: Personality;
+  selected: boolean;
+  onSelect: () => void;
+};
+
+export default function PersonalityCard({ personality, selected, onSelect }: Props) {
+  return (
+    <div
+      className={`border rounded-md p-4 transition cursor-pointer hover:shadow-md ${
+        selected ? 'border-purple-600' : 'border-gray-200'
+      }`}
+      onClick={onSelect}
+    >
+      <div className='flex justify-between items-start mb-2'>
+        <h3 className='text-lg font-semibold'>{personality.name}</h3>
+        {selected && <span className='text-purple-600'>✅</span>}
+      </div>
+      <p className='text-sm text-gray-600 mb-2'>{personality.description}</p>
+      <p className='text-sm italic mb-3'>"{personality.example}"</p>
+      <button
+        onClick={onSelect}
+        className='px-3 py-1 bg-purple-600 text-white rounded'
+      >
+        {selected ? 'Selected' : 'Select'}
+      </button>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/AdminPage.tsx
+++ b/template/app/src/client/pages/AdminPage.tsx
@@ -31,6 +31,7 @@ export default function AdminPage() {
       setEntries((prev) => [...prev, { id: Date.now(), text: newEntry }]);
       setNewEntry('');
     } catch (err) {
+      alert('Failed to inject memory. Please try again.');
       console.error(err);
     }
   };

--- a/template/app/src/client/pages/AdminPage.tsx
+++ b/template/app/src/client/pages/AdminPage.tsx
@@ -22,9 +22,7 @@ export default function AdminPage() {
     }
   }, [user, navigate]);
 
-  if (!user?.isDev) {
-    return <div className='py-10'>Access Denied</div>;
-  }
+  // Authorization check handled in useEffect; redundant rendering removed.
 
   const handleInject = async () => {
     if (!newEntry.trim()) return;

--- a/template/app/src/client/pages/AdminPage.tsx
+++ b/template/app/src/client/pages/AdminPage.tsx
@@ -1,0 +1,69 @@
+import { useAuth } from 'wasp/client/auth';
+import { logMemory } from 'wasp/client/operations';
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+type MemoryEntry = { id: number; text: string };
+
+const initialEntries: MemoryEntry[] = [
+  { id: 1, text: 'Welcome to Norian memory log.' },
+  { id: 2, text: 'This is a sample memory item.' },
+];
+
+export default function AdminPage() {
+  const { data: user } = useAuth();
+  const navigate = useNavigate();
+  const [entries, setEntries] = useState<MemoryEntry[]>(initialEntries);
+  const [newEntry, setNewEntry] = useState('');
+
+  useEffect(() => {
+    if (user && !user.isDev) {
+      navigate('/');
+    }
+  }, [user, navigate]);
+
+  if (!user?.isDev) {
+    return <div className='py-10'>Access Denied</div>;
+  }
+
+  const handleInject = async () => {
+    if (!newEntry.trim()) return;
+    try {
+      await logMemory({ memory: newEntry });
+      setEntries((prev) => [...prev, { id: Date.now(), text: newEntry }]);
+      setNewEntry('');
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleClear = () => setEntries([]);
+
+  return (
+    <div className='py-10 space-y-6'>
+      <h1 className='text-4xl font-bold'>Admin Tools</h1>
+      <div>
+        <h2 className='text-lg font-semibold mb-2'>Memory Log</h2>
+        <ul className='list-disc pl-6 space-y-1'>
+          {entries.map((m) => (
+            <li key={m.id}>{m.text}</li>
+          ))}
+        </ul>
+      </div>
+      <div className='flex flex-col sm:flex-row gap-2'>
+        <input
+          className='flex-1 border rounded-md p-2'
+          value={newEntry}
+          onChange={(e) => setNewEntry(e.target.value)}
+          placeholder='Memory text'
+        />
+        <button onClick={handleInject} className='px-4 py-2 bg-purple-600 text-white rounded-md'>
+          Inject Memory
+        </button>
+        <button onClick={handleClear} className='px-4 py-2 bg-gray-200 rounded-md'>
+          Clear Memory
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/AppPage.tsx
+++ b/template/app/src/client/pages/AppPage.tsx
@@ -1,0 +1,82 @@
+import { askAgent } from 'wasp/client/operations';
+import { useState, useEffect } from 'react';
+
+type ChatMessage = { role: 'user' | 'assistant'; text: string };
+
+export default function AppPage() {
+  const [prompt, setPrompt] = useState('');
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const personalities = ['default', 'mentor', 'sarcastic', 'stoic', 'flirty', 'cowboy'];
+  const [selected, setSelected] = useState<string>(() => localStorage.getItem('personality') || 'default');
+
+  useEffect(() => {
+    localStorage.setItem('personality', selected);
+  }, [selected]);
+
+  const speak = (text: string) => {
+    const utter = new SpeechSynthesisUtterance(text);
+    if (selected === 'flirty') utter.pitch = 1.2;
+    if (selected === 'stoic') utter.rate = 0.9;
+    window.speechSynthesis.speak(utter);
+  };
+
+  const handleSubmit = async () => {
+    if (!prompt.trim()) return;
+    const currentPrompt = prompt;
+    setMessages((prev) => [...prev, { role: 'user', text: currentPrompt }]);
+    setPrompt('');
+    try {
+      setLoading(true);
+      const res = await askAgent({ prompt: currentPrompt, profile: selected });
+      const reply = res?.reply || res?.response || JSON.stringify(res);
+      setMessages((prev) => [...prev, { role: 'assistant', text: reply }]);
+      speak(reply);
+    } catch (err) {
+      console.error(err);
+      setMessages((prev) => [...prev, { role: 'assistant', text: 'Error fetching response.' }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className='py-10 space-y-6'>
+      <h1 className='text-4xl font-bold'>Dashboard</h1>
+      <div>
+        <label className='mr-2'>Personality:</label>
+        <select value={selected} onChange={(e) => setSelected(e.target.value)} className='border p-1 rounded'>
+          {personalities.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className='space-y-3'>
+        {messages.map((m, idx) => (
+          <div key={idx} className={m.role === 'user' ? 'text-right' : 'text-left'}>
+            <span className='inline-block rounded-md px-3 py-2 bg-gray-100'>{m.text}</span>
+          </div>
+        ))}
+        {loading && <div className='text-gray-500 italic'>Thinking...</div>}
+      </div>
+      <div className='flex gap-2'>
+        <input
+          className='flex-1 border rounded-md p-2'
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+          placeholder='Ask the AI...'
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={loading || !prompt.trim()}
+          className='px-4 py-2 bg-purple-600 text-white rounded-md disabled:opacity-50'
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/LabsPage.tsx
+++ b/template/app/src/client/pages/LabsPage.tsx
@@ -1,0 +1,8 @@
+export default function LabsPage() {
+  return (
+    <div className='py-10'>
+      <h1 className='text-4xl font-bold'>Labs</h1>
+      <p className='mt-4 text-lg'>Explore cooperative R&amp;D experiments here.</p>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/MainPage.tsx
+++ b/template/app/src/client/pages/MainPage.tsx
@@ -1,0 +1,8 @@
+export default function MainPage() {
+  return (
+    <div className='py-10'>
+      <h1 className='text-4xl font-bold'>Welcome to Norian</h1>
+      <p className='mt-4 text-lg'>This page uses the Building Blocks template.</p>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/PersonalitiesPage.tsx
+++ b/template/app/src/client/pages/PersonalitiesPage.tsx
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from 'react';
+import PersonalityCard, { Personality } from '../components/PersonalityCard';
+
+const mockPersonalities: Personality[] = [
+  {
+    name: 'Default',
+    description: 'Balanced and neutral tone.',
+    example: 'Hello, how can I assist you today?',
+  },
+  {
+    name: 'Sarcastic',
+    description: 'Dry humor and witty responses.',
+    example: "Oh sure, because that's exactly what you needed.",
+  },
+  {
+    name: 'Mentor',
+    description: 'Supportive and educational.',
+    example: 'Let me guide you through that step by step.',
+  },
+];
+
+export default function PersonalitiesPage() {
+  const [selected, setSelected] = useState<string>(() => localStorage.getItem('personality') || 'Default');
+
+  useEffect(() => {
+    localStorage.setItem('personality', selected);
+  }, [selected]);
+
+  return (
+    <div className='py-10 space-y-6'>
+      <h1 className='text-4xl font-bold mb-4'>Personality Manager</h1>
+      <div className='grid sm:grid-cols-2 md:grid-cols-3 gap-4'>
+        {mockPersonalities.map((p) => (
+          <PersonalityCard
+            key={p.name}
+            personality={p}
+            selected={selected === p.name}
+            onSelect={() => setSelected(p.name)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/ProfilePage.tsx
+++ b/template/app/src/client/pages/ProfilePage.tsx
@@ -1,0 +1,73 @@
+import { useAuth } from 'wasp/client/auth';
+import { useQuery, updatePreferences, getPreferences, togglePublicMode } from 'wasp/client/operations';
+import { useState, useEffect } from 'react';
+
+const dummyPrefs = {
+  food: 'ramen',
+  music: 'lofi',
+  sleep_schedule: 'night owl',
+};
+
+export default function ProfilePage() {
+  const { data: user } = useAuth();
+  const { data: prefsData, refetch } = useQuery(getPreferences);
+  const [useMemory, setUseMemory] = useState(false);
+  const [loadSaved, setLoadSaved] = useState(false);
+  const [usePersonality, setUsePersonality] = useState(false);
+
+  useEffect(() => {
+    if (prefsData) {
+      setUseMemory(prefsData.useMemory);
+      setLoadSaved(prefsData.loadSaved);
+      setUsePersonality(prefsData.usePersonality);
+    }
+  }, [prefsData]);
+
+  if (!user) {
+    return <div className='py-10'>Loading...</div>;
+  }
+
+  return (
+    <div className='py-10 space-y-6'>
+      <h1 className='text-4xl font-bold mb-4'>Your Profile</h1>
+      <div className='border rounded-md p-4 space-y-2'>
+        <p>Email: {user.email}</p>
+        {user.displayName && <p>Display Name: {user.displayName}</p>}
+        <p>Dev User: {user.isDev ? 'Yes' : 'No'}</p>
+        {user.createdAt && <p>Registered: {new Date(user.createdAt).toLocaleDateString()}</p>}
+        <label className='flex items-center gap-2'>
+          <input type='checkbox' checked={user.isPublic} onChange={() => togglePublicMode()} />
+          Public Profile
+        </label>
+      </div>
+      <div className='border rounded-md p-4 space-y-2'>
+        <h2 className='text-xl font-semibold mb-2'>Preferences</h2>
+        <label className='flex items-center gap-2'>
+          <input type='checkbox' checked={useMemory} onChange={(e) => setUseMemory(e.target.checked)} />
+          Use memory
+        </label>
+        <label className='flex items-center gap-2'>
+          <input type='checkbox' checked={loadSaved} onChange={(e) => setLoadSaved(e.target.checked)} />
+          Load saved preferences
+        </label>
+        <label className='flex items-center gap-2'>
+          <input
+            type='checkbox'
+            checked={usePersonality}
+            onChange={(e) => setUsePersonality(e.target.checked)}
+          />
+          Enable personality styling
+        </label>
+        <button
+          onClick={async () => {
+            await updatePreferences({ useMemory, loadSaved, usePersonality });
+            refetch();
+          }}
+          className='mt-2 px-3 py-1 bg-purple-600 text-white rounded-md'
+        >
+          Save Preferences
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/PublicPage.tsx
+++ b/template/app/src/client/pages/PublicPage.tsx
@@ -18,7 +18,8 @@ export default function PublicPage() {
       setReply(res?.reply || JSON.stringify(res));
     } catch (err) {
       console.error(err);
-      setReply('Error fetching response');
+      const errorMessage = err?.message || 'An unexpected error occurred while fetching the response.';
+      setReply(errorMessage);
     } finally {
       setLoading(false);
     }

--- a/template/app/src/client/pages/PublicPage.tsx
+++ b/template/app/src/client/pages/PublicPage.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { askAgentPublic, getPublicUser } from 'wasp/client/operations';
+import { useQuery } from 'wasp/client/operations';
+
+export default function PublicPage() {
+  const { username } = useParams<{ username: string }>();
+  const { data: user, error } = useQuery(getPublicUser, { username: username || '' });
+  const [prompt, setPrompt] = useState('');
+  const [reply, setReply] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSend = async () => {
+    if (!prompt.trim()) return;
+    setLoading(true);
+    try {
+      const res = await askAgentPublic({ prompt });
+      setReply(res?.reply || JSON.stringify(res));
+    } catch (err) {
+      console.error(err);
+      setReply('Error fetching response');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (error) {
+    return <div className='py-10'>User not available</div>;
+  }
+
+  return (
+    <div className='py-10 space-y-6'>
+      <h1 className='text-4xl font-bold'>Share {user?.displayName || username}'s AI</h1>
+      <div className='border rounded-md p-4 space-y-3'>
+        <div>{reply}</div>
+        {loading && <div className='text-gray-500 italic'>Thinking...</div>}
+      </div>
+      <div className='flex gap-2'>
+        <input
+          className='flex-1 border rounded-md p-2'
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleSend()}
+          placeholder='Ask something...'
+        />
+        <button onClick={handleSend} className='px-4 py-2 bg-purple-600 text-white rounded-md'>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/template/app/src/client/pages/TimelinePage.tsx
+++ b/template/app/src/client/pages/TimelinePage.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+const events = [
+  { type: 'memory', content: 'User asked about Norian', timestamp: '2025-06-07T14:23Z' },
+  { type: 'preference', content: "User favored 'lofi music'", timestamp: '2025-06-06T18:02Z' },
+  { type: 'agent', content: "Response returned: 'Norian is online.'", timestamp: '2025-06-06T18:03Z' },
+];
+
+export default function TimelinePage() {
+  return (
+    <div className='py-10 space-y-6'>
+      <h1 className='text-4xl font-bold'>AI Memory Journal</h1>
+      <ul className='border-l pl-4'>
+        {events.map((e, i) => (
+          <li key={i} className='mb-4'>
+            <div className='text-sm text-gray-400'>{e.timestamp}</div>
+            <div className='text-base'>
+              {e.type.toUpperCase()}: {e.content}
+            </div>
+          </li>
+        ))}
+      </ul>
+      <div className='mt-6 text-gray-500'>Token usage graph coming soon.</div>
+    </div>
+  );
+}

--- a/template/app/src/server/ai/agent.ts
+++ b/template/app/src/server/ai/agent.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const askAgent = async (_args: { prompt: string; profile?: string }, context: any) => {
+  const token = context.user?.token;
+  const response = await axios.post(
+    process.env.AXYN_API_URL + '/api/cortex/ask',
+    { prompt: _args.prompt, profile: _args.profile },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return response.data;
+};

--- a/template/app/src/server/ai/memory.ts
+++ b/template/app/src/server/ai/memory.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export const logMemory = async (_args: { memory: string }, context: any) => {
+  const token = context.user?.token;
+  await axios.post(
+    process.env.AXYN_API_URL + '/api/mind/log',
+    { memory: _args.memory },
+    { headers: { Authorization: `Bearer ${token}` } }
+  );
+  return { status: 'ok' };
+};

--- a/template/app/src/server/ai/publicAgent.ts
+++ b/template/app/src/server/ai/publicAgent.ts
@@ -1,0 +1,9 @@
+import axios from 'axios';
+
+export const askPublicAgent = async (_args: { prompt: string; profile?: string }, _context: any) => {
+  const response = await axios.post(process.env.AXYN_API_URL + '/api/cortex/ask', {
+    prompt: _args.prompt,
+    profile: _args.profile,
+  });
+  return response.data;
+};

--- a/template/app/src/server/preferences.ts
+++ b/template/app/src/server/preferences.ts
@@ -1,0 +1,64 @@
+import * as z from 'zod';
+import {
+  type GetPreferences,
+  type UpdatePreferences,
+  type TogglePublicMode,
+  type GetPublicUser,
+} from 'wasp/server/operations';
+import { HttpError, prisma } from 'wasp/server';
+
+export const getPreferences: GetPreferences<void, any> = async (_args, context) => {
+  if (!context.user) {
+    throw new HttpError(401);
+  }
+  const prefs = await context.entities.Preferences.findUnique({ where: { userId: context.user.id } });
+  if (!prefs) {
+    return { useMemory: false, loadSaved: false, usePersonality: false };
+  }
+  return prefs;
+};
+
+const updatePrefsSchema = z.object({
+  useMemory: z.boolean(),
+  loadSaved: z.boolean(),
+  usePersonality: z.boolean(),
+});
+
+type UpdatePrefsInput = z.infer<typeof updatePrefsSchema>;
+
+export const updatePreferences: UpdatePreferences<UpdatePrefsInput, { success: boolean }> = async (
+  rawArgs,
+  context
+) => {
+  if (!context.user) {
+    throw new HttpError(401);
+  }
+  const data = updatePrefsSchema.parse(rawArgs);
+  await context.entities.Preferences.upsert({
+    where: { userId: context.user.id },
+    create: { userId: context.user.id, ...data },
+    update: data,
+  });
+  return { success: true };
+};
+
+export const togglePublicMode: TogglePublicMode<void, boolean> = async (_args, context) => {
+  if (!context.user) {
+    throw new HttpError(401);
+  }
+  const updated = await context.entities.User.update({
+    where: { id: context.user.id },
+    data: { isPublic: !context.user.isPublic },
+  });
+  return updated.isPublic;
+};
+
+export const getPublicUser: GetPublicUser<{ username: string }, any> = async (args, _context) => {
+  const user = await prisma.user.findFirst({
+    where: { username: args.username, isPublic: true },
+  });
+  if (!user) {
+    throw new HttpError(404, 'User not available');
+  }
+  return { username: user.username, displayName: user.displayName };
+};

--- a/template/app/src/server/scripts/dbSeeds.ts
+++ b/template/app/src/server/scripts/dbSeeds.ts
@@ -12,7 +12,8 @@ type MockUserData = Omit<User, 'id'>;
  */
 export async function seedMockUsers(prismaClient: PrismaClient) {
   const users = generateMockUsersData(50);
-  users.push(generateDevUserData());
+  const devUser = ensureUniqueDevUser(generateDevUserData(), users);
+  users.push(devUser);
   const created = await Promise.all(users.map((data) => prismaClient.user.create({ data })));
   await Promise.all(
     created.map((u) =>


### PR DESCRIPTION
## Summary
- create `PersonalityCard` component and `PersonalitiesPage`
- register `/personalities` route in Wasp config
- allow selecting a personality stored in localStorage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68444f5a04e88333b1cc1633924956fd

## Summary by Sourcery

Add Personality Manager UI and related pages for AI interactions, extend user model with dev/public flags and preferences, implement new server operations for AI agent and memory logging, and seed database with a dev user and initial preferences.

New Features:
- Introduce Personality Manager UI with selectable personality cards and localStorage persistence
- Add AI chat interface on AppPage with speech synthesis based on selected personality
- Create Profile, Admin, Public, Timeline, Labs, and Main pages for user preferences, memory logs, and public sharing
- Implement server operations for fetching/updating user preferences, toggling public mode, and logging memory
- Expose public-facing AI chat via askAgentPublic and getPublicUser operations

Enhancements:
- Extend signup fields to include isDev, isPublic, displayName, and preferencesJson with support for DEV_EMAILS env variable
- Seed the database with a dev user and corresponding preferences entries
- Register new client-side routes in Wasp config for all added pages